### PR TITLE
Fix the checksum for the x64 version of the SDK

### DIFF
--- a/dotnetcore-runtime.install/tools/data.ps1
+++ b/dotnetcore-runtime.install/tools/data.ps1
@@ -5,7 +5,7 @@
     Checksum = '490b3adc7922d54ddb9fe15928ce1aff2554a91bc9a7aef6bf988074acf66de63128fb3034401f6238d899ab495597452e244699f9d82813d7ea729054f5b443'
     ChecksumType = 'sha512'
     Url64 = 'https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.exe'
-    Checksum64 = 'efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba'
+    Checksum64 = '1575566e5bdb5f3b954e4ee4f614adfe4b47479abdb638946a3b78dc4a7f4def55b68554619947934913d095590374595c2842b9e987f331db3ba1bc0126e60d'
     ChecksumType64 = 'sha512'
     ApplicationName = 'Microsoft .NET Core Runtime - 2.0.3 *'
     UninstallerName = 'dotnet-runtime-*.exe'


### PR DESCRIPTION
Fix the SHA-512 checksum for `dotnet-runtime-2.0.3-win-x64.exe` (was accidentally the one for `dotnet-runtime-2.0.3-win-x86.zip`) added by #19.